### PR TITLE
FLUID-4199: Set the permissions for the temp and cache directories in the ant build script

### DIFF
--- a/infusionBuilder-deploy/build.xml
+++ b/infusionBuilder-deploy/build.xml
@@ -74,7 +74,9 @@
 
 	<target name="make_dirs">
 		<mkdir dir="${secure_tmp}" />
+		<chmod dir="${secure_tmp}" perm="777" />
 		<mkdir dir="${secure_cache}" />
+		<chmod dir="${secure_cache}" perm="775" />
 	</target>
 
 	<target name="config"


### PR DESCRIPTION
FLUID-4199: Set the permission of cache directory to 775  and tmp directory to 777 in build.xml.
